### PR TITLE
documentation

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -7,6 +7,7 @@ If there is no ./configure create one with autotools:
 $ aclocal
 $ autoconf 
 $ autoheader 
+$ libtoolize
 $ automake --add-missing
 
 


### PR DESCRIPTION
The INSTALL file says: run aclocal, autoconf, etc. but forgets to mention libtoolize. This is an essential step.

btw, you should also up the version number because it seems stuck at 1.3.8 ...?
