### PR TITLE
allow authorization without protocol defined

### DIFF
--- a/libtac/lib/author_r.c
+++ b/libtac/lib/author_r.c
@@ -160,6 +160,9 @@ int tac_author_read(int fd, struct areply *re) {
         free(smsg);
     }
 
+    TACDEBUG((LOG_DEBUG, "%s: authorization reply status=%d",\
+        __FUNCTION__, tb->status));
+
     /* prepare status */
     switch(tb->status) {
         /* success conditions */
@@ -179,6 +182,7 @@ int tac_author_read(int fd, struct areply *re) {
                 pktp = (u_char *) tb + TAC_AUTHOR_REPLY_FIXED_FIELDS_SIZE;
                 argp = pktp + (tb->arg_cnt * sizeof(u_char)) + tb->msg_len +
                     tb->data_len;
+                TACSYSLOG((LOG_WARNING, "Args cnt %d", tb->arg_cnt));
                 /* argp points to current argument string
                    pktp points to current argument length */
                 for(r=0; r < tb->arg_cnt; r++) {
@@ -207,6 +211,7 @@ int tac_author_read(int fd, struct areply *re) {
                     /* now buff points to attribute name,
                        value to the attribute value */
                 }
+                TACSYSLOG((LOG_WARNING, "Adding buf/value pair (%s,%s)", buff, value));
                 tac_add_attrib_pair(&re->attr, buff, sepchar, value);
                 argp += *pktp;
                 pktp++; 
@@ -217,8 +222,6 @@ int tac_author_read(int fd, struct areply *re) {
         break;
     }
 
-    TACDEBUG((LOG_DEBUG, "%s: authorization failed, server reply status=%d",\
-        __FUNCTION__, tb->status))
     switch (tb->status) {
         /* authorization failure conditions */
         /* failing to follow is allowed by RFC, page 23  */

--- a/pam_tacplus.c
+++ b/pam_tacplus.c
@@ -68,7 +68,8 @@ int _pam_send_account(int tac_fd, int type, const char *user, char *tty,
     sprintf(buf, "%hu", task_id);
     tac_add_attrib(&attr, "task_id", buf);
     tac_add_attrib(&attr, "service", tac_service);
-    tac_add_attrib(&attr, "protocol", tac_protocol);
+    if(tac_protocol != NULL && tac_protocol[0] != '\0')
+      tac_add_attrib(&attr, "protocol", tac_protocol);
     if (cmd != NULL) {
         tac_add_attrib(&attr, "cmd", cmd);
     }
@@ -148,12 +149,11 @@ int _pam_account(pam_handle_t *pamh, int argc, const char **argv,
     /* checks for specific data required by TACACS+, which should
        be supplied in command line  */
     if(tac_service == NULL || *tac_service == '\0') {
-        _pam_log (LOG_ERR, "TACACS+ service type not configured");
+        _pam_log (LOG_ERR, "ACC: TACACS+ service type not configured");
         return PAM_AUTH_ERR;
     }
     if(tac_protocol == NULL || *tac_protocol == '\0') {
-        _pam_log (LOG_ERR, "TACACS+ protocol type not configured");
-        return PAM_AUTH_ERR;
+        _pam_log (LOG_ERR, "ACC: TACACS+ protocol type not configured (IGNORED)");
     }
 
     /* when this module is called from within pppd or other
@@ -478,16 +478,16 @@ int pam_sm_acct_mgmt (pam_handle_t * pamh, int flags,
     /* checks for specific data required by TACACS+, which should
        be supplied in command line  */
     if(tac_service == NULL || !*tac_service) {
-        _pam_log (LOG_ERR, "TACACS+ service type not configured");
+        _pam_log (LOG_ERR, "SM: TACACS+ service type not configured");
         return PAM_AUTH_ERR;
     }
     if(tac_protocol == NULL || !*tac_protocol) {
-        _pam_log (LOG_ERR, "TACACS+ protocol type not configured");
-        return PAM_AUTH_ERR;
+        _pam_log (LOG_ERR, "SM: TACACS+ protocol type not configured (IGNORED)");
     }
 
     tac_add_attrib(&attr, "service", tac_service);
-    tac_add_attrib(&attr, "protocol", tac_protocol);
+    if(tac_protocol != NULL && tac_protocol[0] != '\0')
+      tac_add_attrib(&attr, "protocol", tac_protocol);
 
     tac_fd = tac_connect_single(active_server.addr, active_server.key);
     if(tac_fd < 0) {


### PR DESCRIPTION
Protocol is only required for certain subset of services, mainly for ppp. We
allow authorization with empty protocol if user wants to use other service
names, like 'ssh'

From the http://tools.ietf.org/html/draft-grant-tacacs-02 page 30:

```
The protocol attribute is intended for use with PPP. When service equals
"ppp" and protocol equals "lcp", the message describes the PPP link
layer service. For other values of protocol, this describes a PPP NCP
(network layer service). A single PPP session can support multiple NCPs
```
