### PR TITLE
Reset magic_inited

### DIFF
--- a/libtac/lib/magic.c
+++ b/libtac/lib/magic.c
@@ -80,6 +80,9 @@ magic()
         int nb_read = read(rfd, &ret, sizeof(ret));
         close(rfd);
 
+        // Reset magic_inited
+        magic_inited = 0;
+
         if (nb_read < sizeof(ret)) {
             /* on read() error fallback to other method */
             return (u_int32_t)random();


### PR DESCRIPTION
I lost part of my commit just now.
I don't know if the magic() function can be called multiple times.
In case it can, magic_inited needs to be reset.
The proper way to do this should be to have magic_finalize function to close the fd, but I don't know where it would need to be called from. Any ideas?
