### PR TITLE
Reduce loglevel for non-critical author messages

### DIFF
--- a/libtac/lib/author_r.c
+++ b/libtac/lib/author_r.c
@@ -182,7 +182,7 @@ int tac_author_read(int fd, struct areply *re) {
                 pktp = (u_char *) tb + TAC_AUTHOR_REPLY_FIXED_FIELDS_SIZE;
                 argp = pktp + (tb->arg_cnt * sizeof(u_char)) + tb->msg_len +
                     tb->data_len;
-                TACSYSLOG((LOG_WARNING, "Args cnt %d", tb->arg_cnt));
+                TACSYSLOG((LOG_DEBUG, "Args cnt %d", tb->arg_cnt));
                 /* argp points to current argument string
                    pktp points to current argument length */
                 for(r=0; r < tb->arg_cnt; r++) {
@@ -211,7 +211,7 @@ int tac_author_read(int fd, struct areply *re) {
                     /* now buff points to attribute name,
                        value to the attribute value */
                 }
-                TACSYSLOG((LOG_WARNING, "Adding buf/value pair (%s,%s)", buff, value));
+                TACSYSLOG((LOG_DEBUG, "Adding buf/value pair (%s,%s)", buff, value));
                 tac_add_attrib_pair(&re->attr, buff, sepchar, value);
                 argp += *pktp;
                 pktp++; 


### PR DESCRIPTION
Messages like "Args cnt %d", "Adding buf/value pair (%s,%s)" should not
flood syslog as warning.
