### PR TITLE
Fix TACACS+ timeouts in pam_tacplus

### DIFF
--- a/support.c
+++ b/support.c
@@ -259,8 +259,11 @@ int _pam_parse (int argc, const char **argv) {
             /* FIXME atoi() doesn't handle invalid numeric strings well */
             tac_timeout = atoi(*argv + 8);
 
-            if (tac_timeout < 0)
+            if (tac_timeout < 0) {
                 tac_timeout = 0;
+            } else { 
+                tac_readtimeout_enable = 1;
+            }
         } else {
             _pam_log (LOG_WARNING, "unrecognized option: %s", *argv);
         }


### PR DESCRIPTION
If a timeout is configured by PAM, make sure we set the tac_readtimeout_enable to a non-zero value to get TACACS+ timeouts to work as expected. This is necessary as the tac_readtimeout_enable variable is defaulted to 0 in [header.c](/jeroennijhof/pam_tacplus/blob/master/libtac/lib/header.c#L51).
