### PR TITLE
Do not use openlog()/closelog()

### DIFF
--- a/support.c
+++ b/support.c
@@ -46,10 +46,8 @@ void _pam_log(int err, const char *format,...) {
 
     va_start(args, format);
     vsnprintf(msg, sizeof(msg), format, args);
-    openlog("PAM-tacplus", LOG_PID, LOG_AUTH);
-    syslog(err, "%s", msg);
+    syslog(err, "PAM-tacplus: %s", msg);
     va_end(args);
-    closelog();
 }
 
 char *_pam_get_user(pam_handle_t *pamh) {


### PR DESCRIPTION
Changing syslog 'ident' from PAM module causes a problem if the application
using PAM uses its own openlog().
Also calling openlog()/closelog() repeatedly just wastes time.
So simply add "PAM-tacplus:" prefix instead.