### PR TITLE
pam_tacplus: incorrect args parsing

### DIFF
--- a/support.c
+++ b/support.c
@@ -298,12 +298,12 @@ int _pam_parse (int argc, const char **argv) {
                     TAC_PLUS_MAXSERVERS);
             }
         } else if (!strncmp (*argv, "secret=", 7)) {
-            unsigned int i;
+            int i;
 
             current_secret = *argv + 7;     /* points right into argv (which is const) */
 
             /* if 'secret=' was given after a 'server=' parameter, fill in the current secret */
-            for(i = tac_srv_no-1; i != 0; i--) {
+            for(i = tac_srv_no-1; i >= 0; i--) {
                 if (tac_srv[i].key != NULL)
                     break;
 


### PR DESCRIPTION
support.c@306: for(i = tac_srv_no-1; i != 0; i--) {

pam_tacplus secret=123 server=1.1.1.1: tac_srv_no-1 == 0-1 == MAX_UINT -> segfault
pam_tacplus server=1.1.1.1 secret=123: tac_srv_no-1 == 1-1 == 0 -> secret is not set for srv[0]