### PR TITLE
bugfix: encryption packet

### DIFF
--- a/libtac/lib/connect.c
+++ b/libtac/lib/connect.c
@@ -164,9 +164,9 @@ int tac_connect_single(const struct addrinfo *server, const char *key, struct ad
     retval = fd;
 
     /* set current tac_secret */
-    tac_encryption = 0;
+    /* tac_encryption = 0; */
     if (key != NULL && *key) {
-        tac_encryption = 1;
+        /* tac_encryption = 1; */
         tac_secret = key;
     }
 


### PR DESCRIPTION
Encryption flag is already initialized when defining, and can be set to 0 with -n option.
Need to remove the two line code.

Signed-off-by: lyq140 <34637052+lyq140@users.noreply.github.com>