### PR TITLE
Use '%zd' and '%zu' as ssize_t and size_t formatters

### DIFF
--- a/libtac/lib/magic.c
+++ b/libtac/lib/magic.c
@@ -73,7 +73,7 @@ magic()
     	exit(1);
     }
     if(ret < (ssize_t) sizeof(num)) {
-    	TACSYSLOG(LOG_CRIT,"%s: getrandom less bytes than expected: %ld vs %lu", __FUNCTION__, ret, sizeof(num));
+    	TACSYSLOG(LOG_CRIT,"%s: getrandom less bytes than expected: %zd vs %zu", __FUNCTION__, ret, sizeof(num));
     	exit(1);
     }
     return num;


### PR DESCRIPTION
Fixes build error with GCC 8.3.0, for nios2:

In file included from libtac/lib/magic.h:24,
                 from libtac/lib/magic.c:35:
libtac/lib/magic.c: In function ‘magic’:
libtac/lib/magic.c:77:25: error: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘ssize_t’ {aka ‘int’} [-Werror=format=]
      TACSYSLOG(LOG_CRIT,"%s: getrandom less bytes than expected: %ld vs %lu", __FUNCTION__, ret, sizeof(num));
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                ~~~
./libtac/include/libtac.h:70:50: note: in definition of macro ‘TACSYSLOG’
 #define TACSYSLOG(level, fmt, ...) syslog(level, fmt, ## __VA_ARGS__)
                                                  ^~~
libtac/lib/magic.c:77:25: error: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 5 has type ‘unsigned int’ [-Werror=format=]
      TACSYSLOG(LOG_CRIT,"%s: getrandom less bytes than expected: %ld vs %lu", __FUNCTION__, ret, sizeof(num));
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                     ~~~~~~~~~~~
./libtac/include/libtac.h:70:50: note: in definition of macro ‘TACSYSLOG’
 #define TACSYSLOG(level, fmt, ...) syslog(level, fmt, ## __VA_ARGS__)
                                                  ^~~
cc1: all warnings being treated as errors

Signed-off-by: Carlos Santos <unixmania@gmail.com>