### PR TITLE
libtac/lib/magic.c: fix build on uclibc

### DIFF
--- a/libtac/lib/magic.c
+++ b/libtac/lib/magic.c
@@ -18,6 +18,10 @@
  * See `CHANGES' file for revision history.
  */
 
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -26,10 +30,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
-
-#ifdef HAVE_CONFIG_H
-  #include "config.h"
-#endif
 
 #include "magic.h"
 


### PR DESCRIPTION
Commit 7e990f9db6d8805d369876f45964df87efad9e08 replaced `_GNU_SOURCE` by
`AC_SYSTEM_EXTENSIONS`. This is fine but then `config.h` must be included
before system includes otherwise build fails with uclibc on:

```
libtac/lib/magic.c: In function 'magic':
libtac/lib/magic.c:70:11: error: implicit declaration of function 'getrandom' [-Werror=implicit-function-declaration]
     ret = getrandom(&num, sizeof(num), GRND_NONBLOCK);
           ^

```
Fixes:
 - http://autobuild.buildroot.org/results/05c67484136f3bb433ce7fc47b2ce01167048cc2

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>