### PR TITLE
fix libtac2-bin install path when building debian package

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,7 @@ if TACC
 bin_PROGRAMS = tacc
 tacc_SOURCES = tacc.c
 tacc_LDADD = libtac.la
-tacc_CFLAGS = $(AM_CFLAGS) -I $(top_srcdir)/libtac/include @rt_debug_defines@
+tacc_CFLAGS = $(AM_CFLAGS) -g -O0 -I $(top_srcdir)/libtac/include @rt_debug_defines@
 endif
 
 libtac_includedir = $(includedir)/libtac
@@ -51,7 +51,7 @@ libtac_la_SOURCES += \
 libtac/lib/md5.c \
 libtac/lib/md5.h
 endif
-libtac_la_CFLAGS = $(AM_CFLAGS) -I $(top_srcdir)/libtac/include @rt_debug_defines@
+libtac_la_CFLAGS = $(AM_CFLAGS) -g -O0 -I $(top_srcdir)/libtac/include @rt_debug_defines@
 libtac_la_LDFLAGS = -version-info 2:0:0 -shared
 
 moduledir = @pamdir@
@@ -60,7 +60,7 @@ pam_tacplus_la_SOURCES = pam_tacplus.h \
 pam_tacplus.c \
 support.h \
 support.c
-pam_tacplus_la_CFLAGS = $(AM_CFLAGS) -I $(top_srcdir)/libtac/include -I $(top_srcdir)/libtac/lib
+pam_tacplus_la_CFLAGS = $(AM_CFLAGS) -g -O0 -I $(top_srcdir)/libtac/include -I $(top_srcdir)/libtac/lib
 pam_tacplus_la_LDFLAGS = -module -avoid-version
 pam_tacplus_la_LIBADD = libtac.la
 

--- a/debian/libtac2-bin.install
+++ b/debian/libtac2-bin.install
@@ -1,1 +1,1 @@
-usr/sbin
+usr/bin

--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,8 @@
 #export DH_VERBOSE=1
 SHELL := sh -e
 
+export TACC=yes
+
 %:
 	dh  $@ --with autoreconf
 

--- a/debian/rules
+++ b/debian/rules
@@ -24,3 +24,9 @@ override_dh_install:
 	cp debian/tacplus debian/libpam-tacplus/usr/share/pam-configs/
 	dh_install
 
+override_dh_auto_test:
+	mkdir -p /etc/pam.d
+	sudo cp test/test /etc/pam.d/test
+	sudo mkdir -p /etc/tacacs+/
+	sudo cp test/tac_plus.conf /etc/tacacs+
+	dh_auto_test

--- a/pam_tacplus.h
+++ b/pam_tacplus.h
@@ -39,8 +39,8 @@
 
 /* pam_tacplus major, minor and patchlevel version numbers */
 #define PAM_TAC_VMAJ 1
-#define PAM_TAC_VMIN 3
-#define PAM_TAC_VPAT 8
+#define PAM_TAC_VMIN 4
+#define PAM_TAC_VPAT 1
 
 #ifndef PAM_EXTERN
 #define PAM_EXTERN extern

--- a/test/tac_plus.conf
+++ b/test/tac_plus.conf
@@ -1,0 +1,13 @@
+key = testkey123
+user = testuser1 {
+        global = cleartext "testpass123"
+        service = ppp protocol = ip {
+                addr=1.2.3.4
+        }
+}
+user = testuser2 {
+        global = cleartext "testpass123"
+        service = ppp protocol = ip {
+                addr=2.3.4.5
+        }
+}

--- a/test/test
+++ b/test/test
@@ -1,0 +1,4 @@
+#%PAM-1.0
+auth       required /usr/local/lib/security/pam_tacplus.so debug server=127.0.0.1 secret=testkey123
+account	   required /usr/local/lib/security/pam_tacplus.so debug server=127.0.0.1 secret=testkey123 service=ppp protocol=ip
+session    required /usr/local/lib/security/pam_tacplus.so debug server=127.0.0.1 secret=testkey123 server=127.0.0.2 secret=testkey123 service=ppp protocol=ip


### PR DESCRIPTION
Following https://github.com/kravietz/pam_tacplus/issues/142, Here is a small fix in order to build debian package of this repo from source