### PR TITLE
Fix libtac2-bin install path

### DIFF
--- a/debian/libtac2-bin.install
+++ b/debian/libtac2-bin.install
@@ -1,1 +1,1 @@
-usr/sbin
+usr/bin


### PR DESCRIPTION
following https://github.com/kravietz/pam_tacplus/issues/142, here is a small fix in order to build debian packages