### PR TITLE
Fix dh_auto_test during deb build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -24,3 +24,10 @@ override_dh_install:
 	cp debian/tacplus debian/libpam-tacplus/usr/share/pam-configs/
 	dh_install
 
+override_dh_auto_test:
+	mkdir -p /etc/pam.d
+	sudo cp test/test /etc/pam.d/test
+	sudo mkdir -p /etc/tacacs+/
+	sudo cp test/tac_plus.conf /etc/tacacs+
+	dh_auto_test
+	sudo rm -rf /etc/pam.d/test /etc/tacacs+/tac_plus.conf

--- a/test/tac_plus.conf
+++ b/test/tac_plus.conf
@@ -1,0 +1,13 @@
+key = testkey123
+user = testuser1 {
+        global = cleartext "testpass123"
+        service = ppp protocol = ip {
+                addr=1.2.3.4
+        }
+}
+user = testuser2 {
+        global = cleartext "testpass123"
+        service = ppp protocol = ip {
+                addr=2.3.4.5
+        }
+}

--- a/test/test
+++ b/test/test
@@ -1,0 +1,4 @@
+#%PAM-1.0
+auth       required /usr/local/lib/security/pam_tacplus.so debug server=127.0.0.1 secret=testkey123
+account	   required /usr/local/lib/security/pam_tacplus.so debug server=127.0.0.1 secret=testkey123 service=ppp protocol=ip
+session    required /usr/local/lib/security/pam_tacplus.so debug server=127.0.0.1 secret=testkey123 server=127.0.0.2 secret=testkey123 service=ppp protocol=ip


### PR DESCRIPTION
When building debian package using debuild -uc -us -b, dh_auto_test target fails because it tries to get test files that are not on host.

Overrides target dh_auto_test to create test files in proper directories and delete them after test.

This PR relates to issue https://github.com/kravietz/pam_tacplus/issues/146