### PR TITLE
tacc.c: fix build failure if time_t is 64 bits

### DIFF
--- a/tacc.c
+++ b/tacc.c
@@ -343,7 +343,7 @@ int main(int argc, char **argv) {
         /* start accounting */
         struct tac_attrib *attr = NULL;
 
-        sprintf(buf, "%lu", time(0));
+        sprintf(buf, "%llu", time(0));
         tac_add_attrib(&attr, "start_time", buf);
 
         // this is not crypto but merely an identifier
@@ -452,7 +452,7 @@ int main(int argc, char **argv) {
     if (do_account) {
         /* stop accounting */
         struct tac_attrib *attr = NULL;
-        sprintf(buf, "%lu", time(0));
+        sprintf(buf, "%llu", time(0));
         tac_add_attrib(&attr, "stop_time", buf);
         sprintf(buf, "%hu", task_id);
         tac_add_attrib(&attr, "task_id", buf);


### PR DESCRIPTION
Build can can fail if time_t is 64 bits and not 32 bits because of the following warning (which results in a build failure due to `-Werror`):

```
tacc.c: In function 'main':
tacc.c:346:25: error: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'time_t' {aka 'long long int'} [-Werror=format=]
         sprintf(buf, "%lu", time(0));
                       ~~^   ~~~~~~~
                       %llu
```

So replace `%lu` by `%llu`

Fixes:
 - http://autobuild.buildroot.org/results/874433d8cb30d21332f23024081a8b6d7b3254ae

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>