### PR TITLE
fix build failure when time_t is 64 bits

### DIFF
--- a/pam_tacplus.c
+++ b/pam_tacplus.c
@@ -86,10 +86,14 @@ int _pam_send_account(int tac_fd, int type, const char *user, char *tty,
 	char buf[64];
 	struct tac_attrib *attr;
 	int retval;
+	time_t t;
+	struct tm tm;
 
 	attr = (struct tac_attrib *) xcalloc(1, sizeof(struct tac_attrib));
 
-	sprintf(buf, "%lu", (unsigned long) time(NULL));
+	t = time(NULL);
+	gmtime_r(&t, &tm);
+	strftime(buf, sizeof(buf), "%s", &tm);
 
 	if (type == TAC_PLUS_ACCT_FLAG_START) {
 		tac_add_attrib(&attr, "start_time", buf);

--- a/tacc.c
+++ b/tacc.c
@@ -342,8 +342,12 @@ int main(int argc, char **argv) {
     if (do_account) {
         /* start accounting */
         struct tac_attrib *attr = NULL;
+        time_t t;
+        struct tm tm;
 
-        sprintf(buf, "%lu", time(0));
+        t = time(0);
+        gmtime_r(&t, &tm);
+        strftime(buf, sizeof(buf), "%s", &tm);
         tac_add_attrib(&attr, "start_time", buf);
 
         // this is not crypto but merely an identifier
@@ -452,7 +456,11 @@ int main(int argc, char **argv) {
     if (do_account) {
         /* stop accounting */
         struct tac_attrib *attr = NULL;
-        sprintf(buf, "%lu", time(0));
+        time_t t;
+        struct tm tm;
+        t = time(0);
+        gmtime_r(&t, &tm);
+        strftime(buf, sizeof(buf), "%s", &tm);
         tac_add_attrib(&attr, "stop_time", buf);
         sprintf(buf, "%hu", task_id);
         tac_add_attrib(&attr, "task_id", buf);

--- a/tacc.c
+++ b/tacc.c
@@ -343,7 +343,7 @@ int main(int argc, char **argv) {
         /* start accounting */
         struct tac_attrib *attr = NULL;
 
-        sprintf(buf, "%llu", time(0));
+        sprintf(buf, "%lu", time(0));
         tac_add_attrib(&attr, "start_time", buf);
 
         // this is not crypto but merely an identifier
@@ -452,7 +452,7 @@ int main(int argc, char **argv) {
     if (do_account) {
         /* stop accounting */
         struct tac_attrib *attr = NULL;
-        sprintf(buf, "%llu", time(0));
+        sprintf(buf, "%lu", time(0));
         tac_add_attrib(&attr, "stop_time", buf);
         sprintf(buf, "%hu", task_id);
         tac_add_attrib(&attr, "task_id", buf);


### PR DESCRIPTION
Build can fail if `time_t` is 64 bits and not 32 bits because of the following warning (which results in a build failure due to `-Werror`):

```
tacc.c: In function 'main':
tacc.c:346:25: error: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'time_t' {aka 'long long int'} [-Werror=format=]
         sprintf(buf, "%lu", time(0));
                       ~~^   ~~~~~~~
                       %llu
```

Instead of casting `time_t` to unsigned long as already done in pam_tacplus.c, use `strftime` which seems the right approach to convert time_t into a string. While at it, also update pam_tacplus.c.

Fixes:
 - http://autobuild.buildroot.org/results/874433d8cb30d21332f23024081a8b6d7b3254ae