### PR TITLE
libtac: Add support for setting DSCP marking

### DIFF
--- a/libtac/include/libtac.h
+++ b/libtac/include/libtac.h
@@ -163,6 +163,7 @@ extern int tac_readtimeout_enable;
 /* connect.c */
 extern unsigned long tac_timeout;
 
+void tac_set_dscp(uint8_t val);
 int tac_connect(struct addrinfo **, char **, int);
 int tac_connect_single(const struct addrinfo *, const char *, struct addrinfo *,
 		int);


### PR DESCRIPTION
cc @gollub 

Add support for setting a DSCP value on sockets opened by tac_connect
functions.

Clients can use tac_set_dscp() to set the desired global marking to be
used in all IP packets.