### PR TITLE
author_r.c: Support receiving 255 attributes

### DIFF
--- a/libtac/include/libtac.h
+++ b/libtac/include/libtac.h
@@ -120,7 +120,7 @@ struct areply {
 #endif
 
 #ifndef TAC_PLUS_MAX_ARGCOUNT
-#define TAC_PLUS_MAX_ARGCOUNT 100 /* maximum number of arguments passed in packet */
+#define TAC_PLUS_MAX_ARGCOUNT TAC_PLUS_ATTRIB_MAX_CNT /* maximum number of arguments passed in packet */
 #endif
 
 #ifndef TAC_PLUS_PORT


### PR DESCRIPTION
In 8c273a959dbcfddf92621eb700db57240146b21f a limit of 100 was
introduced on the number of attributes which would be processed in
an authorization reply.

However a reply may contain up to 255 attributes, and libtac also
supports sending up to 255 attributes in an authorization request.

Therefore raise TAC_PLUS_MAX_ARGCOUNT to 255 (TAC_PLUS_ATTRIB_MAX_CNT).