### PR TITLE
Check for failure of OpenSSL RAND_[pseudo_]bytes

### DIFF
--- a/pam_tacplus.c
+++ b/pam_tacplus.c
@@ -100,8 +100,13 @@ int _pam_send_account(int tac_fd, int type, const char *user, char *tty,
 	} else if (type == TAC_PLUS_ACCT_FLAG_STOP) {
 		tac_add_attrib(&attr, "stop_time", buf);
 	}
-	sprintf(buf, "%hu", task_id);
+
+	if (task_id == 0)
+		snprintf(buf, sizeof(buf), "%d", getpid());
+	else
+		snprintf(buf, sizeof(buf), "%hu", task_id);
 	tac_add_attrib(&attr, "task_id", buf);
+
 	tac_add_attrib(&attr, "service", tac_service);
 	if (tac_protocol[0] != '\0')
 		tac_add_attrib(&attr, "protocol", tac_protocol);
@@ -720,9 +725,8 @@ int pam_sm_open_session(pam_handle_t *pamh, int UNUSED(flags), int argc,
                         const char **argv) {
 
 /* Task ID has no need to be cryptographically strong so we don't
- * check for failures of the RAND functions. If they fail then we are
- * as well sending the accounting request regardless of whether any value
- * was written to task_id.
+ * check for failures of the RAND functions. If we fail to get an ID we
+ * fallback to using our PID (in _pam_send_account).
  */
 #if defined(HAVE_OPENSSL_RAND_H) && defined(HAVE_LIBCRYPTO)
 # if defined(HAVE_RAND_BYTES)
@@ -733,6 +737,10 @@ int pam_sm_open_session(pam_handle_t *pamh, int UNUSED(flags), int argc,
 #else
 	task_id=(short int) magic();
 #endif
+
+	if (task_id == 0)
+		syslog(LOG_INFO, "%s: failed to generate random task ID, "
+				"falling back to PID", __FUNCTION__);
 
 	return _pam_account(pamh, argc, argv, TAC_PLUS_ACCT_FLAG_START, NULL);
 } /* pam_sm_open_session */

--- a/pam_tacplus.c
+++ b/pam_tacplus.c
@@ -718,6 +718,12 @@ int pam_sm_acct_mgmt(pam_handle_t *pamh, int UNUSED(flags), int argc,
 PAM_EXTERN
 int pam_sm_open_session(pam_handle_t *pamh, int UNUSED(flags), int argc,
                         const char **argv) {
+
+/* Task ID has no need to be cryptographically strong so we don't
+ * check for failures of the RAND functions. If they fail then we are
+ * as well sending the accounting request regardless of whether any value
+ * was written to task_id.
+ */
 #if defined(HAVE_OPENSSL_RAND_H) && defined(HAVE_LIBCRYPTO)
 # if defined(HAVE_RAND_BYTES)
 	RAND_bytes((unsigned char *) &task_id, sizeof(task_id));


### PR DESCRIPTION
Discovered by @gollub.

magic.c: check for failure of RAND_[pseudo_]bytes

When magic() is implemented via libcrypto's RAND_bytes or
RAND_pseudo_bytes we should check for a failure and abort to
ensure we don't use a predictable session_id.

This prevents (further) weakening* of the TACACS+ protocol
"encryption" since session_id is an input to the algorithm.

*by modern standards TACACS+ is deemed "obfuscated" - RFC 8907.

pam_tacplus.c: Fallback to using PID as task ID

If there is a failure obtaining a random task ID for the session
accounting request then fallback to using the PID, as this is unique
for the lifetime of the PAM application and therefore session.