### PR TITLE
Add an option to disable -Werror

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,11 @@
 
 ACLOCAL_AMFLAGS = -I config
 AUTOMAKE_OPTIONS = subdir-objects
-AM_CFLAGS = -Wall -Wextra -Werror
+AM_CFLAGS = -Wall -Wextra
+
+if ENABLE_WERROR
+AM_CFLAGS += -Werror
+endif
 
 if TACC
 bin_PROGRAMS = tacc

--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,9 @@ AC_SUBST(pamdir)
 AC_ARG_ENABLE(doc, AS_HELP_STRING([--disable-doc], [do not build docs]))
 AM_CONDITIONAL(DOC, test "x$enable_doc" != "xno")
 
+AC_ARG_ENABLE(werror, AS_HELP_STRING([--disable-werror], [do not build with -Werror]))
+AM_CONDITIONAL(ENABLE_WERROR, test "x$enable_werror" != "xno")
+
 dnl --------------------------------------------------------------------
 dnl Switch for run-time debugging
 AC_ARG_ENABLE(runtime-debugging, [AS_HELP_STRING([--enable-runtime-debugging],


### PR DESCRIPTION
Allow the user to disable -Werror to avoid the following build failure
with gcc 4.8:

```
libtac/lib/magic.c:138:13: error: ignoring return value of 'read', declared with attribute warn_unused_result [-Werror=unused-result]
             (void) read(rfd, &seed, sizeof(seed));
             ^
```

Fixes:
 - http://autobuild.buildroot.org/results/5c17226f12eba104d907693ec37fc101cc6d447f

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>