### PR TITLE
Fix format specifier errors for 32-bit compilation

### DIFF
--- a/libtac/lib/acct_s.c
+++ b/libtac/lib/acct_s.c
@@ -199,7 +199,7 @@ int tac_acct_send(int fd, int type, const char *user, char *tty,
 
     if (w < TAC_PLUS_HDR_SIZE) {
         TACSYSLOG(
-                LOG_ERR, "%s: short write on header, wrote %ld of %d: %m", __FUNCTION__, w, TAC_PLUS_HDR_SIZE);
+                LOG_ERR, "%s: short write on header, wrote %zd of %d: %m", __FUNCTION__, w, TAC_PLUS_HDR_SIZE);
         free(pkt);
         free(th);
         return LIBTAC_STATUS_WRITE_ERR;
@@ -212,7 +212,7 @@ int tac_acct_send(int fd, int type, const char *user, char *tty,
     w = write(fd, pkt, pkt_len);
     if (w < (ssize_t) pkt_len) {
         TACSYSLOG(
-                LOG_ERR, "%s: short write on body, wrote %ld of %lu: %m", __FUNCTION__, w, pkt_len);
+                LOG_ERR, "%s: short write on body, wrote %zd of %zu: %m", __FUNCTION__, w, pkt_len);
         ret = LIBTAC_STATUS_WRITE_ERR;
     }
 

--- a/libtac/lib/attrib.c
+++ b/libtac/lib/attrib.c
@@ -74,7 +74,7 @@ static int _tac_add_attrib_pair(gl_list_t attr, char *name, char separator, char
     check = snprintf(buf, total_len + 1, "%s%c%s", name, separator, value);
     if (check < (int) total_len) {
         TACSYSLOG(LOG_ERR,
-                  "%s: short snprintf write: wanted %lu bytes, wrote %d",
+                  "%s: short snprintf write: wanted %zu bytes, wrote %d",
                   __FUNCTION__, total_len, check);
     }
 

--- a/libtac/lib/authen_s.c
+++ b/libtac/lib/authen_s.c
@@ -157,7 +157,7 @@ int tac_authen_send(int fd, const char *user, const char *pass, const char *tty,
     w = write(fd, th, TAC_PLUS_HDR_SIZE);
     if (w < TAC_PLUS_HDR_SIZE) {
         TACSYSLOG(
-                LOG_ERR, "%s: short write on header, wrote %ld of %d: %m", __FUNCTION__, w, TAC_PLUS_HDR_SIZE);
+                LOG_ERR, "%s: short write on header, wrote %zd of %d: %m", __FUNCTION__, w, TAC_PLUS_HDR_SIZE);
         free(token);
         free(pkt);
         free(th);
@@ -188,7 +188,7 @@ int tac_authen_send(int fd, const char *user, const char *pass, const char *tty,
     free(pkt);
     if (w < (ssize_t) pkt_len) {
         TACSYSLOG(
-                LOG_ERR, "%s: short write on body, wrote %ld of %zu: %m", __FUNCTION__, w, pkt_len);
+                LOG_ERR, "%s: short write on body, wrote %zd of %zu: %m", __FUNCTION__, w, pkt_len);
         ret = LIBTAC_STATUS_WRITE_ERR;
     }
 

--- a/libtac/lib/author_s.c
+++ b/libtac/lib/author_s.c
@@ -180,7 +180,7 @@ int tac_author_send(int fd, const char *user, char *tty, char *r_addr,
 
     if (w < TAC_PLUS_HDR_SIZE) {
         TACSYSLOG(
-                LOG_ERR, "%s: short write on header, wrote %ld of %d: %m", __FUNCTION__, w, TAC_PLUS_HDR_SIZE);
+                LOG_ERR, "%s: short write on header, wrote %zd of %d: %m", __FUNCTION__, w, TAC_PLUS_HDR_SIZE);
         free(pkt);
         free(th);
         return LIBTAC_STATUS_WRITE_ERR;
@@ -193,7 +193,7 @@ int tac_author_send(int fd, const char *user, char *tty, char *r_addr,
     w = write(fd, pkt, pkt_len);
     if (w < (ssize_t) pkt_len) {
         TACSYSLOG(
-                LOG_ERR, "%s: short write on body, wrote %ld of %lu: %m", __FUNCTION__, w, pkt_len);
+                LOG_ERR, "%s: short write on body, wrote %zd of %zu: %m", __FUNCTION__, w, pkt_len);
         ret = LIBTAC_STATUS_WRITE_ERR;
     }
 

--- a/libtac/lib/crypt.c
+++ b/libtac/lib/crypt.c
@@ -58,7 +58,7 @@ void digest_chap(unsigned char *digest, unsigned char id,
     check = getrandom(challenge, challenge_len, 0);
     if (check < (ssize_t) challenge_len) {
         TACSYSLOG(LOG_ERR,
-                  "%s: getrandom failed, produced %ld bytes, expected %ld",
+                  "%s: getrandom failed, produced %zd bytes, expected %zu",
                   __FUNCTION__, check, challenge_len);
 #ifdef HAVE_ABORT
         abort();

--- a/libtac/lib/header.c
+++ b/libtac/lib/header.c
@@ -78,7 +78,7 @@ uint32_t _get_session_id(void)
   if (ret < (ssize_t) sizeof(tmp))
   {
     TACSYSLOG(LOG_ERR,
-              "%s: getrandom failed, produced %ld bytes, expected %ld",
+              "%s: getrandom failed, produced %zd bytes, expected %zu",
               __FUNCTION__, ret, sizeof(tmp));
 #ifdef HAVE_ABORT
     abort();


### PR DESCRIPTION
Variables of type size_t were using %lu as format specifier. When compiled using 32-bit compiler, %lu is expecting unsigned long, but size_t translates to unsigned int.
So, replacing it with %zu and %zd (for ssize_t) as per c99 standard.