### PR TITLE
Use of AC_CHECK_FILE prevents cross compilation.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,14 +31,17 @@ export PATH=\$PATH:\$HOME/gnulib
 
 ])
 
-AC_CHECK_FILE([lib/malloc.c], [], [AC_MSG_ERROR([
+if ! test -f "lib/malloc.c"; then
+AC_MSG_ERROR([
+lib/malloc.c not found!
 Gnulib files not imported. Run:
 
 $ac_cv_prog_GNULIB --makefile-name=Makefile.gnulib --libtool --import \
 fcntl crypto/md5 array-list list xlist getrandom realloc-posix \
 explicit_bzero xalloc getopt-gnu
 
-])])
+])
+fi
 
 dnl --------------------------------------------------------------------
 dnl Checks for programs.

--- a/libtac/lib/authen_r.c
+++ b/libtac/lib/authen_r.c
@@ -139,7 +139,6 @@ int tac_authen_read_timeout(int fd, struct areply *re, unsigned long timeout)
 		memset(msg, 0, (tb->msg_len + 1));
 		memcpy(msg, (char *)tb + sizeof(struct authen_reply), tb->msg_len);
 		re->msg = msg;
-		free(msg);
 	}
 
 	/* server authenticated username and password successfully */


### PR DESCRIPTION
The use of AC_CHECK_FILE causes the following error when cross compiling:

  configure: error: cannot check for file existence when cross compiling

The solution is to check for the file directly instead of using a macro.

Signed-off-by: Rahul Sreeram <rahul.sreeram@gmail.com>