### PR TITLE
libtac: fix double free in tac_acct_read_timeout

### DIFF
--- a/libtac/lib/acct_r.c
+++ b/libtac/lib/acct_r.c
@@ -139,8 +139,7 @@ int tac_acct_read_timeout(int fd, struct areply *re, unsigned long timeout)
         msg = (char *)xcalloc(1, tb->msg_len + 1);
         memcpy(msg, (unsigned char *)tb + TAC_ACCT_REPLY_FIXED_FIELDS_SIZE, tb->msg_len);
         msg[(int)tb->msg_len] = '\0';
-        re->msg = msg;
-        free(msg);
+        re->msg = msg; /* Freed by caller */
     }
 
     /* server logged our request successfully */


### PR DESCRIPTION
Core dumped due:
"free(): double free detected in tcache 2"

re->msg should be freed by the caller as in comment 6380c5a81ea6, else it will create a dangling pointer.

Fixes: 6380c5a81ea6 ("Replace deprecated bcopy() by memcpy()")

Fix #201  